### PR TITLE
feat: implement EmailJS contact form integration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
+        "@emailjs/browser": "^4.4.1",
         "@tailwindcss/forms": "^0.5.10",
         "@tailwindcss/typography": "^0.5.16",
         "@types/react-dom": "^19.1.9",
@@ -34,6 +35,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@emailjs/browser": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@emailjs/browser/-/browser-4.4.1.tgz",
+      "integrity": "sha512-DGSlP9sPvyFba3to2A50kDtZ+pXVp/0rhmqs2LmbMS3I5J8FSOgLwzY2Xb4qfKlOVHh29EAutLYwe5yuEZmEFg==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@emnapi/runtime": {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@emailjs/browser": "^4.4.1",
     "@tailwindcss/forms": "^0.5.10",
     "@tailwindcss/typography": "^0.5.16",
     "@types/react-dom": "^19.1.9",

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,10 @@
+name = "personal-portfolio"
+compatibility_date = "2024-01-01"
+
+[build]
+command = "npm run build"
+watch_dir = "."
+
+[build.upload]
+format = "service-worker"
+dir = "out"


### PR DESCRIPTION
- Add @emailjs/browser package for client-side email sending
- Replace mailto fallback with professional EmailJS integration
- Add form validation and error handling
- Support 200 free emails/month vs previous 50 limit
- Fully compatible with static export and Cloudflare Pages
- No server-side functions required
- Environment variables for secure configuration